### PR TITLE
[Issue #1] Fix MCP Configuration Format (servers vs mcpServers)

### DIFF
--- a/.template/scripts/clean-reset.sh
+++ b/.template/scripts/clean-reset.sh
@@ -159,7 +159,7 @@ echo ""
 echo -e "${BLUE}[4/5] Resetting MCP configuration...${NC}"
 
 if [ -f "$PROJECT_ROOT/.vscode/mcp.json" ]; then
-    echo '{"mcpServers": {}}' > "$PROJECT_ROOT/.vscode/mcp.json"
+    echo '{"servers": {}}' > "$PROJECT_ROOT/.vscode/mcp.json"
     echo "  ✓ Reset .vscode/mcp.json to default state"
 else
     echo "  ℹ .vscode/mcp.json does not exist (nothing to reset)"
@@ -230,7 +230,7 @@ fi
 MCP_OK=true
 if [ -f "$PROJECT_ROOT/.vscode/mcp.json" ]; then
     MCP_CONTENT=$(cat "$PROJECT_ROOT/.vscode/mcp.json" | tr -d '[:space:]')
-    if [ "$MCP_CONTENT" != '{"mcpServers":{}}' ]; then
+    if [ "$MCP_CONTENT" != '{"servers":{}}' ]; then
         echo -e "  ${RED}✗ .vscode/mcp.json is not in default state${NC}"
         MCP_OK=false
     fi

--- a/.template/scripts/init.sh
+++ b/.template/scripts/init.sh
@@ -150,8 +150,8 @@ merge_configs() {
     # Create .vscode directory if it doesn't exist
     mkdir -p "$VSCODE_DIR"
 
-    # Start with empty mcpServers object
-    local merged_json='{"mcpServers":{}}'
+    # Start with empty servers object
+    local merged_json='{"servers":{}}'
 
     local configured_servers=()
 
@@ -173,12 +173,12 @@ with open('$file', 'r') as f:
     new_config = json.load(f)
 
 # Merge configurations
-if 'mcpServers' in new_config:
-    for key, value in new_config['mcpServers'].items():
-        merged['mcpServers'][key] = value
-elif 'servers' in new_config:
+if 'servers' in new_config:
     for key, value in new_config['servers'].items():
-        merged['mcpServers'][key] = value
+        merged['servers'][key] = value
+elif 'mcpServers' in new_config:
+    for key, value in new_config['mcpServers'].items():
+        merged['servers'][key] = value
 
 # Output merged config
 print(json.dumps(merged, indent=2))


### PR DESCRIPTION
## Issue

Closes #1

## Summary

Fixed critical bug preventing MCP servers from loading in VS Code. Scripts were generating the deprecated `"mcpServers"` format, but VS Code requires the `"servers"` format as per the official MCP specification.

## Changes Made

- **init.sh (line 154)**: Changed initial JSON object key from `"mcpServers"` to `"servers"`
- **init.sh (lines 176-181)**: Updated Python merge logic to:
  - Prioritize new `"servers"` format
  - Fall back to old `"mcpServers"` format for backward compatibility
  - Always output merged config with `"servers"` key
- **clean-reset.sh (line 162)**: Updated `.vscode/mcp.json` reset to use `"servers"` format
- **clean-reset.sh (line 233)**: Updated verification check to validate new format

## Acceptance Criteria

- [x] `init.sh` generates `.vscode/mcp.json` with `"servers"` key
- [x] Merge logic outputs `"servers"` key for all merged configurations
- [x] `clean-reset.sh` creates empty config with `"servers"` key
- [x] Verification check matches new format
- [x] All scripts pass Bash syntax validation
- [x] Backward compatibility maintained - handles both old and new formats

## Testing Performed

- Bash syntax validation: ✓ Both scripts pass (`bash -n`)
- Code review: ✓ All locations updated consistently
- Backward compatibility: ✓ Old `mcpServers` format handled in merge logic

## Breaking Changes

None - changes are backward compatible. System handles both old `mcpServers` and new `servers` formats in configuration files, but always outputs the new `servers` format to `.vscode/mcp.json`.