### PR TITLE
[Issue #25] Add .env file support for MCP server credentials

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,51 @@
+# .env.template - Environment Variables for MCP Server Configuration
+#
+# INSTRUCTIONS:
+# 1. Copy this file to .env: cp .env.template .env
+# 2. Fill in your actual credentials in the .env file
+# 3. IMPORTANT: .env is gitignored - never commit it to version control
+#
+# When you run init.sh, these environment variables will automatically
+# populate the .vscode/mcp.json file with your credentials.
+#
+
+# ============================================================================
+# GitHub MCP Server
+# ============================================================================
+# Get your personal access token from: https://github.com/settings/tokens
+# Required scopes: repo (for repository access)
+GITHUB_PERSONAL_ACCESS_TOKEN=your_token_here
+
+# ============================================================================
+# AWS MCP Servers (awsCore.json, aws.json)
+# ============================================================================
+# Get credentials from AWS IAM console
+AWS_ACCESS_KEY_ID=your_key_here
+AWS_SECRET_ACCESS_KEY=your_secret_here
+AWS_REGION=us-east-1
+
+# ============================================================================
+# Azure MCP Server
+# ============================================================================
+# Get from Azure Portal
+AZURE_SUBSCRIPTION_ID=your_subscription_id_here
+AZURE_TENANT_ID=your_tenant_id_here
+AZURE_CLIENT_ID=your_client_id_here
+AZURE_CLIENT_SECRET=your_client_secret_here
+
+# ============================================================================
+# Docker MCP Server
+# ============================================================================
+# Default Docker socket location (optional - uncomment if needed)
+# DOCKER_HOST=unix:///var/run/docker.sock
+
+# ============================================================================
+# Additional MCP Server Credentials
+# ============================================================================
+# Add environment variables for any additional MCP servers you configure
+# Format: VARIABLE_NAME=value
+#
+# Examples:
+# ANTHROPIC_API_KEY=your_key_here
+# OPENAI_API_KEY=your_key_here
+# SLACK_BOT_TOKEN=your_token_here

--- a/README.md
+++ b/README.md
@@ -71,6 +71,48 @@ This single command will process all your emails and generate complete project d
 
 ---
 
+## 🔐 Environment Variables (MCP Credentials)
+
+MCP servers often require credentials (API tokens, access keys, etc.). Store these securely in a `.env` file:
+
+### Setup
+
+1. **Copy the template:**
+   ```bash
+   cp .env.template .env
+   ```
+
+2. **Edit `.env` with your credentials:**
+   ```bash
+   # GitHub token from https://github.com/settings/tokens
+   GITHUB_PERSONAL_ACCESS_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+   
+   # AWS credentials
+   AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+   AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCY
+   AWS_REGION=us-east-1
+   ```
+
+3. **Run `./go.sh` or `init.sh`:**
+   - Credentials will be automatically populated in `.vscode/mcp.json`
+   - If `.env` doesn't exist, placeholders will remain (you'll need to edit mcp.json manually)
+
+### Security
+
+✅ **Safe** - `.env` is gitignored and will never be committed  
+✅ **Safe** - `.vscode/mcp.json` is also gitignored  
+✅ **Safe** - `.env.template` contains placeholders only (safe to commit)  
+❌ **Never** commit `.env` or share it - it contains your real credentials
+
+### Benefits
+
+- **Security**: Credentials in single gitignored file, never accidentally committed
+- **Simplicity**: Edit one `.env` file instead of complex JSON
+- **Documentation**: `.env.template` documents all required variables
+- **Standard**: Industry-standard pattern familiar to developers
+
+---
+
 ## ⚠️ SECURITY WARNING
 
 **IMPORTANT**: The `email/` directory may contain sensitive information from your email communications. Before committing to a public repository:

--- a/core/mcpServers/aws.json
+++ b/core/mcpServers/aws.json
@@ -5,9 +5,9 @@
       "command": "npx",
       "args": ["-y", "mcp-server-aws"],
       "env": {
-        "AWS_ACCESS_KEY_ID": "<your_aws_access_key>",
-        "AWS_SECRET_ACCESS_KEY": "<your_aws_secret_key>",
-        "AWS_REGION": "us-east-1"
+        "AWS_ACCESS_KEY_ID": "${AWS_ACCESS_KEY_ID}",
+        "AWS_SECRET_ACCESS_KEY": "${AWS_SECRET_ACCESS_KEY}",
+        "AWS_REGION": "${AWS_REGION}"
       }
     }
   }

--- a/core/mcpServers/azure.json
+++ b/core/mcpServers/azure.json
@@ -5,10 +5,10 @@
       "command": "npx",
       "args": ["-y", "mcp-server-azure"],
       "env": {
-        "AZURE_SUBSCRIPTION_ID": "<your_subscription_id>",
-        "AZURE_TENANT_ID": "<your_tenant_id>",
-        "AZURE_CLIENT_ID": "<your_client_id>",
-        "AZURE_CLIENT_SECRET": "<your_client_secret>"
+        "AZURE_SUBSCRIPTION_ID": "${AZURE_SUBSCRIPTION_ID}",
+        "AZURE_TENANT_ID": "${AZURE_TENANT_ID}",
+        "AZURE_CLIENT_ID": "${AZURE_CLIENT_ID}",
+        "AZURE_CLIENT_SECRET": "${AZURE_CLIENT_SECRET}"
       }
     }
   }

--- a/core/mcpServers/github.json
+++ b/core/mcpServers/github.json
@@ -5,7 +5,7 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-github"],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "PLACEHOLDER"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     }
   }


### PR DESCRIPTION
## Issue

Closes #25

## Summary

Implements comprehensive `.env` file support for managing MCP server credentials securely. Users can now store all sensitive credentials (GitHub tokens, AWS keys, Azure credentials, etc.) in a single `.env` file that automatically populates `.vscode/mcp.json` when running `init.sh`.

## Changes Made

### 1. Created `.env.template`
- Template file with all MCP server environment variables
- Clear documentation for each credential (where to get it, what it's for)
- Safe to commit (contains only placeholders)

### 2. Enhanced `init.sh` with three new functions:

**`load_env_file()`:**
- Sources `.env` file if it exists
- Uses `set -a` to auto-export all variables
- Provides clear warning if `.env` not found
- Error handling for invalid `.env` syntax

**`substitute_env_vars()`:**
- Python-based JSON processing to replace `${VAR_NAME}` placeholders
- Recursively handles nested objects, arrays, and strings
- Preserves placeholders if environment variable not set
- Robust error handling

**`check_placeholders()`:**
- Warns if configuration contains unsubstituted placeholders
- Helps users identify missing credentials
- Non-blocking (warning only)

### 3. Updated MCP Server Configurations

Updated to use environment variable placeholders:
- **github.json**: `${GITHUB_PERSONAL_ACCESS_TOKEN}`
- **aws.json**: `${AWS_ACCESS_KEY_ID}`, `${AWS_SECRET_ACCESS_KEY}`, `${AWS_REGION}`
- **azure.json**: `${AZURE_SUBSCRIPTION_ID}`, `${AZURE_TENANT_ID}`, `${AZURE_CLIENT_ID}`, `${AZURE_CLIENT_SECRET}`

### 4. Updated Documentation

Added comprehensive **Environment Variables** section to README.md:
- Setup instructions (copy template, edit, run init.sh)
- Security notes (what's gitignored, what's safe)
- Benefits explanation
- Clear visual indicators (✅/❌)

### 5. .gitignore

`.env` already properly gitignored - no changes needed

## Workflow

**Before (Manual):**
```
1. Run init.sh → generates .vscode/mcp.json with placeholders
2. Manually open .vscode/mcp.json
3. Find each "PLACEHOLDER" or "<your_token>"
4. Replace with actual credentials
5. Risk: Accidentally commit sensitive data
```

**After (Automated):**
```
1. Copy .env.template to .env
2. Edit .env with credentials (one simple file)
3. Run init.sh → automatically populates mcp.json
4. Done! Credentials never at risk
```

## Security Benefits

✅ **Credentials in single location** - Easy to manage and audit  
✅ **Gitignored by default** - `.env` never committed  
✅ **Standard pattern** - Industry-standard dotenv approach  
✅ **Clear documentation** - `.env.template` documents all variables  
✅ **Backward compatible** - Still works if user manually edits mcp.json  
✅ **Validates substitution** - Warns if placeholders remain

## Acceptance Criteria

- [x] `.env.template` created in project root with all MCP server variables
- [x] `.env` added to `.gitignore` (already present)
- [x] All `core/mcpServers/*.json` files updated with `${VAR_NAME}` placeholders
- [x] `init.sh` enhanced with:
  - [x] `load_env_file()` function to source .env
  - [x] `substitute_env_vars()` function to replace placeholders
  - [x] Warning if .env doesn't exist
  - [x] `check_placeholders()` validation function
- [x] README.md updated with .env documentation
- [x] Generated `.vscode/mcp.json` will have actual values (when .env exists)
- [x] Generated `.vscode/mcp.json` will have placeholders (when .env missing)
- [x] No credentials hardcoded anywhere in repository
- [x] Bash syntax validation passes

## Testing Notes

Tested scenarios:
- **No .env file**: Script runs, warns user, creates mcp.json with placeholders ✅
- **With .env file**: Placeholders correctly substituted with actual values ✅
- **Bash syntax**: `bash -n core/scripts/init.sh` passes ✅

## Breaking Changes

None - fully backward compatible. Users who don't create `.env` will get the previous behavior (placeholders in mcp.json that need manual editing).

## Example

**`.env` file:**
```bash
GITHUB_PERSONAL_ACCESS_TOKEN=ghp_abc123
AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG
AWS_REGION=us-east-1
```

**Result in `.vscode/mcp.json`:**
```json
{
  "servers": {
    "github": {
      "env": {
        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_abc123"
      }
    },
    "aws": {
      "env": {
        "AWS_ACCESS_KEY_ID": "AKIAIOSFODNN7EXAMPLE",
        "AWS_SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG",
        "AWS_REGION": "us-east-1"
      }
    }
  }
}
```

## Files Changed

- `.env.template` (created) - Template with all MCP variables
- `core/scripts/init.sh` (+103 lines) - Environment loading and substitution
- `core/mcpServers/github.json` - Updated with `${GITHUB_PERSONAL_ACCESS_TOKEN}`
- `core/mcpServers/aws.json` - Updated with AWS env vars
- `core/mcpServers/azure.json` - Updated with Azure env vars
- `README.md` - Added Environment Variables section

**Total**: +186 lines, -8 lines