### PR TITLE
[Issue #44] Fix broken relative links in updateSummary prompt

### DIFF
--- a/prompts/updateSummary.prompt.md
+++ b/prompts/updateSummary.prompt.md
@@ -265,7 +265,7 @@ The summary should include:
 - Auto-generate from `aiDocs/DISCOVERY.md` high-priority unanswered questions
 - Organize by category (Critical, Technical, Environmental, Historical)
 - List questions concisely without full metadata
-- Add footer note: "*For complete question details including who to ask and where to check, see [aiDocs/DISCOVERY.md](aiDocs/DISCOVERY.md)*"
+- Add footer note: "*For complete question details including who to ask and where to check, see [aiDocs/DISCOVERY.md](../aiDocs/DISCOVERY.md)*"
 
 #### Next Steps
 - Immediate next actions
@@ -286,27 +286,27 @@ After updating `PROJECT.md`, generate simplified, human-readable extracts in the
 - Group by organization
 - Include: Name, Email, Role, Organization
 - Add "Last Updated" date
-- Note: "*For complete contact details, see [aiDocs/SUMMARY.md](aiDocs/SUMMARY.md)*"
+- Note: "*For complete contact details, see [aiDocs/SUMMARY.md](../aiDocs/SUMMARY.md)*"
 
 **docs/TASKS.md:**
 - Extract high-priority tasks from `aiDocs/TASKS.md`
 - Include: Task ID, Description, Owner, Status
 - Separate sections: High Priority, Current Blockers, Recently Completed
 - Add "Last Updated" date
-- Note: "*For complete task list with all metadata, see [aiDocs/TASKS.md](aiDocs/TASKS.md)*"
+- Note: "*For complete task list with all metadata, see [aiDocs/TASKS.md](../aiDocs/TASKS.md)*"
 
 **docs/DECISIONS.md:**
 - Extract decision log from `aiDocs/SUMMARY.md`
 - Table format: Date, Decision, Made By, Rationale
 - Add "Last Updated" date
-- Note: "*For complete decision log, see [aiDocs/SUMMARY.md](aiDocs/SUMMARY.md)*"
+- Note: "*For complete decision log, see [aiDocs/SUMMARY.md](../aiDocs/SUMMARY.md)*"
 
 **docs/QUESTIONS.md:**
 - Extract high-priority unanswered questions from `aiDocs/DISCOVERY.md`
 - Group by category (High Priority, Technical)
 - List questions concisely without full metadata
 - Add "Last Updated" date
-- Note: "*For complete question details including who to ask and where to check, see [aiDocs/DISCOVERY.md](aiDocs/DISCOVERY.md)*"
+- Note: "*For complete question details including who to ask and where to check, see [aiDocs/DISCOVERY.md](../aiDocs/DISCOVERY.md)*"
 
 **Update State File**: After summary generation completes:
 ```python


### PR DESCRIPTION
Closes #44

## Summary

Fixed broken relative path links in `prompts/updateSummary.prompt.md` that were preventing proper navigation from the prompts directory to aiDocs files.

## Changes Made

Updated 5 markdown links to use correct relative paths:

- **Line 268**: `aiDocs/DISCOVERY.md` → `../aiDocs/DISCOVERY.md`
- **Line 289**: `aiDocs/SUMMARY.md` → `../aiDocs/SUMMARY.md`
- **Line 296**: `aiDocs/TASKS.md` → `../aiDocs/TASKS.md`
- **Line 302**: `aiDocs/SUMMARY.md` → `../aiDocs/SUMMARY.md`
- **Line 309**: `aiDocs/DISCOVERY.md` → `../aiDocs/DISCOVERY.md`

## Acceptance Criteria

- [x] Line 268: DISCOVERY.md link uses `../aiDocs/` prefix
- [x] Line 289: SUMMARY.md link uses `../aiDocs/` prefix
- [x] Line 296: TASKS.md link uses `../aiDocs/` prefix
- [x] Line 302: SUMMARY.md link uses `../aiDocs/` prefix
- [x] Line 309: DISCOVERY.md link uses `../aiDocs/` prefix
- [x] All markdown links now have correct relative paths
- [x] No other broken links remain in the file

## Validation

Verified with grep that all markdown link references to aiDocs now use `../aiDocs/` prefix:

```bash
grep -n "](aiDocs/" prompts/updateSummary.prompt.md
# Returns no results - all links fixed
```

## Impact

✅ **Navigation Fixed**: Links in generated docs/ files now correctly reference source aiDocs/ files  
✅ **Validation Unblocked**: Broken link checks will now pass  
✅ **Documentation Integrity**: Ensures users can navigate between summary and source files

## Breaking Changes

None - purely corrective fix.

## Notes

- This was blocking validation checks as mentioned in issue #44
- All links verified to work correctly from prompts/ directory context
- Only changed markdown link targets, not prose references or backtick-wrapped paths