### PR TITLE
[Issue #32] Document /endToEndTest in README Quick Reference Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Use /projectInit
 | **Generate status report** | `/generateReport` | Create executive summary for stakeholders |
 | **Reload AI context** | `/projectInit` | Re-initialize AI with project knowledge |
 | **Validate task structure** | `/validateTasks` | Check task IDs, dependencies, metadata |
+| **Test complete workflow** | `/endToEndTest` | Validate entire system end-to-end |
 | **Clean up old tasks** | `/cleanupTasks` | Archive old tasks, optimize organization |
 | **Fix broken documentation** | `/syncFromProject` | Sync user edits from PROJECT.md to aiDocs/ |
 | **Complete GitHub issue** | `/completeIssue <number>` | Automated Issue→Branch→PR workflow |


### PR DESCRIPTION
Closes #32

## Summary

Added `/endToEndTest` command to the README.md Quick Reference Card to improve command discoverability.

## Changes Made

Updated [README.md](README.md#L125) Quick Reference Card table:
- **Added**: `| **Test complete workflow** | `/endToEndTest` | Validate entire system end-to-end |`
- **Position**: Placed after `/validateTasks` for logical grouping with other validation commands

## Before

Quick Reference Card had 12 commands but was missing `/endToEndTest`:
- ✅ `/validateTasks` - Check task structure
- ❌ `/endToEndTest` - Missing
- ✅ `/cleanupTasks` - Archive old tasks

## After

Quick Reference Card now has 13 commands with `/endToEndTest` documented:
- ✅ `/validateTasks` - Check task structure
- ✅ `/endToEndTest` - Validate entire system end-to-end
- ✅ `/cleanupTasks` - Archive old tasks

## Acceptance Criteria

- [x] Add `/endToEndTest` entry to README Quick Reference Card
- [x] Entry includes: description, command, and what it does
- [x] Positioned logically near other validation commands
- [x] Table formatting maintained correctly
- [x] Command matches actual prompt filename (`prompts/endToEndTest.prompt.md`)

## Impact

✅ **Improved Discoverability** - Users can now find the end-to-end test command  
✅ **Complete Documentation** - All available commands now documented  
✅ **Better Grouping** - Validation commands grouped together logically

## Breaking Changes

None - purely additive documentation update.

## Notes

- Command exists in `prompts/endToEndTest.prompt.md` and is functional
- This update ensures the README matches available functionality
- Positioned after `/validateTasks` as both are validation-related commands