### PR TITLE
[Issue #62] Add Bear (.textbundle) support to notes converter

### DIFF
--- a/core/aiScripts/notesToMd/README.md
+++ b/core/aiScripts/notesToMd/README.md
@@ -1,11 +1,12 @@
 # Notes to Markdown Converter
 
-Converts notes files (.txt, .md, .docx) to standardized Markdown format for AI processing.
+Converts notes files (.txt, .md, .docx, .textbundle) to standardized Markdown format for AI processing.
 
 ## Features
 
-- Processes `.txt`, `.md`, and `.docx` files
+- Processes `.txt`, `.md`, `.docx`, and `.textbundle` files
 - **OneNote support**: Extracts text from `.docx` exports with heading preservation
+- **Bear support**: Parses `.textbundle` format with metadata preservation
 - Extracts metadata:
   - Title (from first line or filename)
   - Author (if present in content)
@@ -34,12 +35,21 @@ python3 core/aiScripts/notesToMd/notes_to_md_converter.py
 
 ```
 notes/
-├── raw/         # Place notes files here (.txt, .md, .docx)
+├── raw/         # Place notes files here (.txt, .md, .docx, .textbundle)
 ├── ai/          # Converted Markdown files (AI-readable)
 └── processed/   # Original files after conversion
 ```
 
 ## Workflow
+
+### Bear Export
+
+1. In Bear, select a note and choose **File → Export Notes**
+2. Choose **TextBundle** format
+3. Save the `.textbundle` file to `notes/raw/`
+4. Run the converter script
+5. Converted notes appear in `notes/ai/` with metadata preserved
+6. Original files moved to `notes/processed/`
 
 ### OneNote Export
 


### PR DESCRIPTION
Closes #62

## Summary

Adds Bear .textbundle format support to the notes converter, enabling direct import of Bear note exports alongside existing .txt, .md, and .docx support.

## Changes Made

- **New Functions:**
  - `parse_textbundle()` - Extracts content and metadata from .textbundle format
  - Handles both directory and ZIP-based .textbundle files

- **Updated Functions:**
  - `detect_format()` - Now recognizes .textbundle files and directories
  - `process_notes_file()` - Routes .textbundle to parse_textbundle()
  - `main()` - Globs for *.textbundle files

- **Features:**
  - Extracts metadata from info.json (creator, version, type)
  - Preserves markdown content from text.md or text.txt
  - Supports both file and directory .textbundle formats
  - Adds metadata as HTML comments in output
  - Standard library only (no new dependencies)

- **Documentation:**
  - Updated README.md with Bear export workflow
  - Added .textbundle to supported formats list
  - Documented export process from Bear app

- **Testing:**
  - Created sample_bear_note.textbundle test data
  - Validated with real .textbundle conversion
  - All 35 smoke tests pass

## Acceptance Criteria

- [x] parse_textbundle() function implemented
- [x] detect_format() recognizes .textbundle files/directories
- [x] Main converter routes .textbundle to parse_textbundle()
- [x] Extracts text.md content successfully
- [x] Parses info.json for metadata
- [x] Test data added (sample_bear_note.textbundle)
- [x] Bear .textbundle files process successfully
- [x] Updated core/aiScripts/notesToMd/README.md

## Testing Performed

- ✅ Python syntax validation (py_compile)
- ✅ All 35 smoke tests pass
- ✅ Tested with sample Bear .textbundle export
- ✅ Verified metadata extraction from info.json
- ✅ Verified content extraction from text.md
- ✅ Confirmed file archival workflow
- ✅ Tested directory-based .textbundle format

## Breaking Changes

None - this is additive functionality only.

## Notes

This is subtask 2 of 3 for issue #58 (notes platform support). After this merges:
- Previous: Issue #61 - OneNote .docx support ✅
- Current: Issue #62 - Bear .textbundle support (this PR)
- Next: Issue #63 - Apple Notes HTML support
- Finally: Close parent issue #58